### PR TITLE
Generate access token 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source 'https://rubygems.org'
 
+gem 'jwt'
 gem 'octokit'
 gem 'semantic'
-
 group :development, :test do
   gem 'pry'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
+    jwt (2.2.2)
     method_source (1.0.0)
     minitest (5.14.3)
     multipart-post (2.1.1)
@@ -94,6 +95,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  jwt
   octokit
   pry
   rspec
@@ -102,4 +104,4 @@ DEPENDENCIES
   simplycop
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -27,7 +27,7 @@ class Config
   def bearer_token
     payload = {
       iat: Time.now.to_i,
-      exp: Time.now.to_i + (10 * 60),
+      exp: Time.now.to_i + (TEN_MINUTES),
       iss: ENV['DOBBY_APP_ID']
     }
     private_key = OpenSSL::PKey::RSA.new(ENV['DOBBY_PRIVATE_KEY'])

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -2,15 +2,37 @@
 
 require 'octokit'
 require 'json'
+require 'jwt'
 
 # configuration for octokit
 class Config
   attr_reader :client, :payload, :version_file_path, :event_name
 
   def initialize
-    @client = Octokit::Client.new(access_token: ENV['ACCESS_TOKEN'])
+    @client = Octokit::Client.new(access_token: access_token)
     @payload = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
     @event_name = ENV['GITHUB_EVENT_NAME']
     @version_file_path = ENV['VERSION_FILE_PATH']
   end
+
+  private
+
+  def access_token
+    bearer_client = Octokit::Client.new(bearer_token: bearer_token)
+    installation = bearer_client.find_repository_installation(payload['repository']['full_name'])
+    response = bearer_client.create_app_installation_access_token(installation[:id])
+    response[:token]
+  end
+
+  def bearer_token
+    payload = {
+      iat: Time.now.to_i,
+      exp: Time.now.to_i + (10 * 60),
+      iss: ENV['DOBBY_APP_ID']
+    }
+    private_key = OpenSSL::PKey::RSA.new(ENV['DOBBY_PRIVATE_KEY'])
+
+    JWT.encode(payload, private_key, 'RS256')
+  end
 end
+

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,10 +11,10 @@ class Config
   attr_reader :client, :payload, :version_file_path, :event_name
 
   def initialize
-    @client = Octokit::Client.new(access_token: access_token)
     @payload = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
     @event_name = ENV['GITHUB_EVENT_NAME']
     @version_file_path = ENV['VERSION_FILE_PATH']
+    @client = Octokit::Client.new(access_token: access_token)
   end
 
   private

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -35,4 +35,3 @@ class Config
     JWT.encode(payload, private_key, 'RS256')
   end
 end
-

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -4,6 +4,8 @@ require 'octokit'
 require 'json'
 require 'jwt'
 
+TEN_MINUTES = 600 # seconds
+
 # configuration for octokit
 class Config
   attr_reader :client, :payload, :version_file_path, :event_name

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -29,7 +29,7 @@ class Config
   def bearer_token
     payload = {
       iat: Time.now.to_i,
-      exp: Time.now.to_i + (TEN_MINUTES),
+      exp: Time.now.to_i + TEN_MINUTES,
       iss: ENV['DOBBY_APP_ID']
     }
     private_key = OpenSSL::PKey::RSA.new(ENV['DOBBY_PRIVATE_KEY'])


### PR DESCRIPTION
### What

We generate the access token from the github app so we dont need https://github.com/simplybusiness/approved-github-actions/pull/7

### Why

There are some security concern if we should use an external github action.