### PR TITLE
upgrade bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,4 +100,4 @@ DEPENDENCIES
   simplycop
 
 BUNDLED WITH
-   2.2.19
+   2.4.12


### PR DESCRIPTION
This updates the version of bundler in the lock file which solves a deprecation warning which appears when running rspec. See [here](https://github.com/rubygems/rubygems/issues/5234).