### PR TITLE
prep for simplycop bump

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,9 +11,9 @@ class Config
   attr_reader :client, :payload, :version_file_path, :event_name
 
   def initialize
-    @payload = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
-    @event_name = ENV['GITHUB_EVENT_NAME']
-    @version_file_path = ENV['VERSION_FILE_PATH']
+    @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH', nil)))
+    @event_name = ENV.fetch('GITHUB_EVENT_NAME', nil)
+    @version_file_path = ENV.fetch('VERSION_FILE_PATH', nil)
     @client = Octokit::Client.new(access_token: access_token)
   end
 
@@ -30,9 +30,9 @@ class Config
     payload = {
       iat: Time.now.to_i,
       exp: Time.now.to_i + TEN_MINUTES,
-      iss: ENV['DOBBY_APP_ID']
+      iss: ENV.fetch('DOBBY_APP_ID', nil)
     }
-    private_key = OpenSSL::PKey::RSA.new(ENV['DOBBY_PRIVATE_KEY'])
+    private_key = OpenSSL::PKey::RSA.new(ENV.fetch('DOBBY_PRIVATE_KEY', nil))
 
     JWT.encode(payload, private_key, 'RS256')
   end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,9 +11,9 @@ class Config
   attr_reader :client, :payload, :version_file_path, :event_name
 
   def initialize
-    @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH', nil)))
-    @event_name = ENV.fetch('GITHUB_EVENT_NAME', nil)
-    @version_file_path = ENV.fetch('VERSION_FILE_PATH', nil)
+    @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
+    @event_name = ENV.fetch('GITHUB_EVENT_NAME')
+    @version_file_path = ENV.fetch('VERSION_FILE_PATH')
     @client = Octokit::Client.new(access_token: access_token)
   end
 
@@ -30,9 +30,9 @@ class Config
     payload = {
       iat: Time.now.to_i,
       exp: Time.now.to_i + TEN_MINUTES,
-      iss: ENV.fetch('DOBBY_APP_ID', nil)
+      iss: ENV.fetch('DOBBY_APP_ID')
     }
-    private_key = OpenSSL::PKey::RSA.new(ENV.fetch('DOBBY_PRIVATE_KEY', nil))
+    private_key = OpenSSL::PKey::RSA.new(ENV.fetch('DOBBY_PRIVATE_KEY'))
 
     JWT.encode(payload, private_key, 'RS256')
   end

--- a/spec/lib/action_spec.rb
+++ b/spec/lib/action_spec.rb
@@ -6,10 +6,11 @@ describe Action do
   let(:client) { instance_double(Octokit::Client) }
 
   let(:config) do
-    OpenStruct.new(
-      client: client,
-      version_file_path: 'lib/version.rb',
-      payload: {
+    test_config = double
+    allow(test_config).to receive(:client).and_return(client)
+    allow(test_config).to receive(:version_file_path).and_return('lib/version.rb')
+    allow(test_config).to receive(:payload).and_return(
+      {
         'repository' => { 'full_name' => repo_full_name },
         'issue' => {
           'number' => 1
@@ -19,6 +20,7 @@ describe Action do
         }
       }
     )
+    test_config
   end
 
   let(:action) { Action.new(config) }

--- a/spec/lib/command_spec.rb
+++ b/spec/lib/command_spec.rb
@@ -3,13 +3,15 @@
 require_relative '../spec_helper'
 describe Command do
   let(:config) do
-    OpenStruct.new(
-      payload: {
+    test_config = double
+    allow(test_config).to receive(:payload).and_return(
+      {
         'comment' => {
           'body' => body
         }
       }
     )
+    test_config
   end
 
   describe 'initialize' do


### PR DESCRIPTION
This fixes Style/FetchEnvVar and Style/OpenStructUse cops which should allow the SimplyCop upgrade to go ahead.