### PR TITLE
[POWR] Enclosing version value in double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ jobs:
           # Change to the file path where you keep the Gem's version.
           # It is usually `lib/<gem name>/version.rb` or in the gemspec file.
           VERSION_FILE_PATH: <VERSION FILE PATH>
+          # You can set PREFER_DOUBLE_QUOTES to "yes" if you want Dobby to 
+          # enclose the new version value in double quotes instead of single quotes ("no" is the default).
+          PREFER_DOUBLE_QUOTES: <yes|no>
 ```
 
 **NOTE:** Workflow will only work once it merged to default (usually master) branch. It is because event `issue_comment` only work on default branch. See [discussion](https://github.community/t/on-issue-comment-events-are-not-triggering-workflows/16784/4) for more detail.

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -56,7 +56,7 @@ class Action
   def updated_version_file(content, level)
     version = fetch_version(content)
     updated_version = version.increment!(level.to_sym)
-    quote = prefer_double_quotes ? '"' : '\''
+    quote = prefer_double_quotes ? '"' : "'"
 
     content.gsub(SEMVER_VERSION, "#{quote}#{updated_version}#{quote}")
   end

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -4,7 +4,7 @@ require 'octokit'
 require 'semantic'
 # Run action based on the command
 class Action
-  attr_reader :client, :version_file_path, :repo, :head_branch, :base_branch, :comment_id
+  attr_reader :client, :version_file_path, :repo, :head_branch, :base_branch, :comment_id, :prefer_double_quotes
 
   SEMVER_VERSION =
     /["'](0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']/ # rubocop:disable Layout/LineLength
@@ -17,6 +17,7 @@ class Action
     payload = config.payload
     @repo = payload['repository']['full_name']
     @comment_id = payload['comment']['id']
+    @prefer_double_quotes = config.prefer_double_quotes
 
     assign_pr_attributes!(payload['issue']['number'])
   end
@@ -55,7 +56,9 @@ class Action
   def updated_version_file(content, level)
     version = fetch_version(content)
     updated_version = version.increment!(level.to_sym)
-    content.gsub(SEMVER_VERSION, "'#{updated_version}'")
+    quote = prefer_double_quotes ? '"' : '\''
+
+    content.gsub(SEMVER_VERSION, "#{quote}#{updated_version}#{quote}")
   end
 
   def add_reaction(reaction)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -9,12 +9,13 @@ TEN_MINUTES = 600 # seconds
 
 # configuration for octokit
 class Config
-  attr_reader :client, :payload, :version_file_path, :event_name
+  attr_reader :client, :payload, :version_file_path, :event_name, :prefer_double_quotes
 
   def initialize
     @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
     @event_name = ENV.fetch('GITHUB_EVENT_NAME')
     @version_file_path = ENV.fetch('VERSION_FILE_PATH')
+    @prefer_double_quotes = ENV.fetch('PREFER_DOUBLE_QUOTES', 'no') == 'yes'
     @client = Octokit::Client.new(access_token: access_token)
   end
 

--- a/spec/lib/action_spec.rb
+++ b/spec/lib/action_spec.rb
@@ -4,6 +4,7 @@ require 'ostruct'
 require_relative '../spec_helper'
 describe Action do
   let(:client) { instance_double(Octokit::Client) }
+  let(:prefer_double_quotes) { false }
 
   let(:config) do
     test_config = double
@@ -20,6 +21,7 @@ describe Action do
         }
       }
     )
+    allow(test_config).to receive(:prefer_double_quotes).and_return(prefer_double_quotes)
     test_config
   end
 
@@ -52,6 +54,16 @@ describe Action do
       expected_content = version_file_content('1.0.1')
       updated_content = action.updated_version_file(content, 'patch')
       expect(updated_content).to eq(expected_content)
+    end
+
+    context 'when prefer_double_quotes configuration options is enabled' do
+      let(:prefer_double_quotes) { true }
+
+      it 'encloses the new version value in double quotes' do
+        expected_content = version_file_content('1.0.1', '"')
+        updated_content = action.updated_version_file(content, 'patch')
+        expect(updated_content).to eq(expected_content)
+      end
     end
   end
 

--- a/spec/support/helpers/response_helper.rb
+++ b/spec/support/helpers/response_helper.rb
@@ -30,7 +30,7 @@ module Helpers
       ).and_raise(Octokit::UnprocessableEntity)
     end
 
-    def version_file_content(version, quote = '\'')
+    def version_file_content(version, quote = "'")
       %(
         module TestRepo
           VERSION=#{quote}#{version}#{quote}

--- a/spec/support/helpers/response_helper.rb
+++ b/spec/support/helpers/response_helper.rb
@@ -30,10 +30,10 @@ module Helpers
       ).and_raise(Octokit::UnprocessableEntity)
     end
 
-    def version_file_content(version)
+    def version_file_content(version, quote = '\'')
       %(
         module TestRepo
-          VERSION='#{version}'
+          VERSION=#{quote}#{version}#{quote}
         end
        )
     end


### PR DESCRIPTION
## What
This PR allows Dobby to enclose the new version value in double quotes instead of single quotes

## How
By introducing a new configuration option which can be set using `PREFER_DOUBLE_QUOTES` environment variable

## Why
- some rubocop's configs require usage of double quotes, e.g. https://github.com/simplybusiness/payments_config/pull/66/files#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cR12
- I want dobby to bump a version in `package.json` file in the trade selector gem (https://github.com/simplybusiness/trade_selector/blob/master/package.json). The file's format requires double quotes