### PR TITLE
Let content be handled separately

### DIFF
--- a/lib/utils/content.rb
+++ b/lib/utils/content.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Content
+  def initialize(config:, ref:, path:)
+    @result = config.client.contents(config.payload['repository']['full_name'], path: path, query: { ref: ref })
+  rescue Octokit::NotFound => e
+    puts "::error file=#{path},title=Error fetching file #{path}::#{e.message} "
+    raise e
+  end
+
+  def content
+    Base64.decode64(@result['content'])
+  end
+
+  def blob_sha
+    @result['sha']
+  end
+end

--- a/spec/lib/utils/content_spec.rb
+++ b/spec/lib/utils/content_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+describe Content do
+  let(:client) { instance_double(Octokit::Client) }
+  let(:config) do
+    test_config = double
+    allow(test_config).to receive_messages(
+      client: client, version_file_path: 'lib/version.rb', payload: {
+        'repository' => { 'full_name' => repo_full_name },
+        'issue' => {
+          'number' => 1
+        },
+        'comment' => {
+          'id' => 123
+        }
+      })
+    test_config
+  end
+  let(:content) { Content.new(config: config, ref: 'master', path: 'lib/version.rb') }
+
+  it 'fetch the content for a given file on a branch' do
+    mock_version_response(client, '1.0.0', 'master')
+    expect(client).to receive(:contents).with(
+      repo_full_name,
+      path: 'lib/version.rb',
+      query: { ref: 'master' }
+    )
+    fetched_content = content.content
+    expect(fetched_content).to eq(version_file_content('1.0.0'))
+  end
+
+  it 'fetch the blob_sha for a given file on a branch' do
+    mock_version_response(client, '1.0.0', 'master')
+    expect(client).to receive(:contents).with(
+      repo_full_name,
+      path: 'lib/version.rb',
+      query: { ref: 'master' }
+    )
+    fetched_content = content.blob_sha
+    expect(fetched_content).to eq('abc1234')
+  end
+end

--- a/spec/lib/utils/content_spec.rb
+++ b/spec/lib/utils/content_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../../spec_helper'
+require_relative '../../../lib/utils/content'
+
 describe Content do
   let(:client) { instance_double(Octokit::Client) }
   let(:config) do

--- a/spec/lib/utils/content_spec.rb
+++ b/spec/lib/utils/content_spec.rb
@@ -14,7 +14,8 @@ describe Content do
         'comment' => {
           'id' => 123
         }
-      })
+      }
+    )
     test_config
   end
   let(:content) { Content.new(config: config, ref: 'master', path: 'lib/version.rb') }


### PR DESCRIPTION
This has the advantage of making only one API call (vs. 2 currently, each time you want sha and also want the content) and removes the responsibility away from the main `action.rb`.

For now it just creates the new Content class, usage will come in a future PR.

Issue: https://github.com/simplybusiness/dobby/issues/138