### PR TITLE
Prefer double quotes is not required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ jobs:
           # Change to the file path where you keep the Gem's version.
           # It is usually `lib/<gem name>/version.rb` or in the gemspec file.
           VERSION_FILE_PATH: <VERSION FILE PATH>
-          # You can set PREFER_DOUBLE_QUOTES to "yes" if you want Dobby to 
-          # enclose the new version value in double quotes instead of single quotes ("no" is the default).
-          PREFER_DOUBLE_QUOTES: <yes|no>
 ```
 
 **NOTE:** Workflow will only work once it merged to default (usually master) branch. It is because event `issue_comment` only work on default branch. See [discussion](https://github.community/t/on-issue-comment-events-are-not-triggering-workflows/16784/4) for more detail.

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -7,8 +7,7 @@ require_relative 'utils/bump'
 
 # Run action based on the command
 class Action
-  attr_reader :client, :version_file_path, :other_version_file_paths, :repo, :head_branch, :base_branch, :comment_id,
-              :prefer_double_quotes
+  attr_reader :client, :version_file_path, :other_version_file_paths, :repo, :head_branch, :base_branch, :comment_id
 
   VALID_SEMVER_LEVELS = ['minor', 'major', 'patch'].freeze
 
@@ -20,7 +19,6 @@ class Action
     @other_version_file_paths = config.other_version_file_paths
     @repo = payload['repository']['full_name']
     @comment_id = payload['comment']['id']
-    @prefer_double_quotes = config.prefer_double_quotes
 
     assign_pr_attributes!(payload['issue']['number'])
   end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -9,14 +9,13 @@ TEN_MINUTES = 600 # seconds
 
 # configuration for octokit
 class Config
-  attr_reader :client, :payload, :version_file_path, :other_version_file_paths, :event_name, :prefer_double_quotes
+  attr_reader :client, :payload, :version_file_path, :other_version_file_paths, :event_name
 
   def initialize
     @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
     @event_name = ENV.fetch('GITHUB_EVENT_NAME')
     @version_file_path = ENV.fetch('VERSION_FILE_PATH')
     @other_version_file_paths = ENV.fetch('OTHER_VERSION_FILE_PATHS').split(",")
-    @prefer_double_quotes = ENV.fetch('PREFER_DOUBLE_QUOTES', 'no') == 'yes'
     @client = Octokit::Client.new(access_token: access_token)
   end
 

--- a/spec/lib/action_spec.rb
+++ b/spec/lib/action_spec.rb
@@ -4,7 +4,6 @@ require 'ostruct'
 require_relative '../spec_helper'
 describe Action do
   let(:client) { instance_double(Octokit::Client) }
-  let(:prefer_double_quotes) { false }
   let(:other_version_file_paths) { [] }
 
   let(:config) do
@@ -18,7 +17,7 @@ describe Action do
         'comment' => {
           'id' => 123
         }
-      }, prefer_double_quotes: prefer_double_quotes, other_version_file_paths: other_version_file_paths
+      }, other_version_file_paths: other_version_file_paths
     )
     test_config
   end


### PR DESCRIPTION
It was made redundant due to how version bumping is handled now. The core logic has changed to basically find the old version, the new version, and then running a simple search and replace to update the version in every file.

Issue: https://github.com/simplybusiness/dobby/issues/138