### PR TITLE
Convert `./` to a relative string

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -14,7 +14,7 @@ class Config
   def initialize
     @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
     @event_name = ENV.fetch('GITHUB_EVENT_NAME')
-    @version_file_path = ENV.fetch('VERSION_FILE_PATH')
+    @version_file_path = ENV.fetch('VERSION_FILE_PATH').sub('./', '')
     @other_version_file_paths = ENV.fetch('OTHER_VERSION_FILE_PATHS', "").split(",")
     @client = Octokit::Client.new(access_token: access_token)
   end


### PR DESCRIPTION
Unfortunately the create tree API call can't handle `./` it looks like. This change always gives a consistent relative path.

Issue: https://github.com/simplybusiness/dobby/issues/138