### PR TITLE
Generalise

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 “Dobby is free.”
 
-A Github action which provides chat-ops functionality. You can comment on Pull request to perform various operations.
-Currently it supports bumping version for a gem.
+A Github action which provides chat-ops functionality. You can comment on a pull request to perform various operations.
+Currently it supports bumping version files in Ruby, Python and Javascript. The version file (see below) must specify the version
+as a key-value pair separated by either ":" or "=", e.g. `VERSION: '1.2.3'` or `version = 1.2.3` 
 
 ## Bump version
 
@@ -14,8 +15,8 @@ Dobby requires a Github App to be installed either on an individual repository o
    - Set GitHub App name. 
    - Set Homepage URL to your github repository.
    - Uncheck Active under Webhook. You do not need to enter a Webhook URL.
-   - Under Repository permissions: Contents select Access: Read & write.
-   - Under Repository permissions: Pull requests select Access: Read & write. 
+   - Under Permissions & Events > Repository permissions > Contents select Access: Read & write.
+   - Under Permissions & Events > Repository permissions > Pull requests select Access: Read & write. 
 
 2. Create a Private key from the App settings page and store it securely.
 

--- a/lib/command.rb
+++ b/lib/command.rb
@@ -11,8 +11,8 @@ class Command
   def initialize(config)
     @config = config
     comment = config.payload['comment']['body'].strip.downcase
-    error_msg = "Comment must be start with #{COMMAND_PREFIX}"
-    puts "::error title=Arguement Error::#{error_msg}"
+    error_msg = "Comment must start with #{COMMAND_PREFIX}"
+    puts "::error title=Argument Error::#{error_msg}"
     raise ArgumentError, error_msg unless comment.start_with?(COMMAND_PREFIX)
 
     cmd = comment.delete_prefix(COMMAND_PREFIX)

--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -4,9 +4,10 @@ require_relative 'content'
 require_relative 'commit'
 
 class Bump
-  SEMVER_VERSION =
-    /["'](0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']/ # rubocop:disable Layout/LineLength
-  GEMSPEC_VERSION = Regexp.new(/\.version\s*=\s*/.to_s + SEMVER_VERSION.to_s).freeze
+  SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/
+  SEPARATOR = /\s*[:=]\s*/
+  VERSION_KEY = /version/
+  VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config, level)
     @config = config
@@ -56,8 +57,8 @@ class Bump
   end
 
   def fetch_version(content)
-    version = content.content.match(GEMSPEC_VERSION) || content.content.match(SEMVER_VERSION)
-    Semantic::Version.new(version[0].split('=').last.gsub(/\s/, '').gsub(/'|"/, ''))
+    version = content.content.match(VERSION_SETTING)
+    Semantic::Version.new(version[0].split(SEPARATOR).last.gsub(/\s/, '').gsub(/'|"/, ''))
   end
 
   def bump_version(version, level)

--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -6,7 +6,7 @@ require_relative 'commit'
 class Bump
   SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
-  VERSION_KEY = /version/
+  VERSION_KEY = /(^|\.|\s)version/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config, level)

--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -4,7 +4,7 @@ require_relative 'content'
 require_relative 'commit'
 
 class Bump
-  SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/
+  SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
   VERSION_KEY = /version/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze


### PR DESCRIPTION
The reason dobby worked with other languages is because of L59 in `lib/utils/bump.rb`. Files like `package.json` and `pyproject.toml` were matching on the second part of the condition - the semver regex. It just so happened that in these files the first match is usually an app version number, but it's not guaranteed. 

This PR generalises and strengthens the regex matching. Now a match on just a version number will not work. Instead it matches on case insensitive "version" followed by a combo of spaces and a ":" or "=" separator, followed by a version number. This will hopefully make this more robust for python and js (and possibly other languages that version in a similar way).