### PR TITLE
Retain modified version file content when bumping version

### DIFF
--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -25,9 +25,8 @@ class Bump
     commit = Commit.new(@config)
     files = []
     @other_version_file_paths.push(@version_file_path).each do |version_file_path|
-      base_branch_content = Content.new(config: @config, ref: @base_branch, path: version_file_path)
       head_branch_content = Content.new(config: @config, ref: @head_branch, path: version_file_path)
-      updated_base_branch_content = base_branch_content.content.gsub @version.to_s, @updated_version.to_s
+      updated_base_branch_content = head_branch_content.content.gsub @version.to_s, @updated_version.to_s
 
       if head_branch_content.content == updated_base_branch_content
         puts "::notice title=Nothing to update::The desired version bump is already present for: #{version_file_path}"

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -68,5 +68,23 @@ RSpec.describe Bump do
         "#{version_file_path}\n"
       ).to_stdout
     end
+
+    it 'retains modified version file content' do
+      allow(head_content).to receive(:content).and_return('version: 1.0.0 extra stuff here')
+      allow(base_content).to receive(:content).and_return('version: 1.0.0')
+
+      bump = Bump.new(config, 'patch')
+      expect(commit).to receive(:multiple_files).with(
+        [
+          {
+            path: other_version_file_paths[0], mode: '100644', type: 'blob',
+            content: 'version: 1.0.1 extra stuff here'
+          },
+          { path: version_file_path, mode: '100644', type: 'blob', content: 'version: 1.0.1 extra stuff here' }
+        ],
+        'Bump patch version'
+      )
+      bump.bump_everything
+    end
   end
 end


### PR DESCRIPTION
When bumping the version, the content of the version file is updated to the new version. This change retains the modified content of the version file when bumping the version, for example, if any packages in the `package.json` file are updated.

For example, [this commit](https://github.com/simplybusiness/embedded-cd/pull/44/commits/0ae349bfd70bf8517897303ddaf8df3e639ac012) updated the `version` field, as requested, but it reverted all the changes to the package dependencies.