### PR TITLE
Allow people to be polite to their robots again

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -8,7 +8,6 @@ class Command
 
   COMMAND_PREFIX = '/dobby'
 
-  # Improved version of the initialize method in command.rb
   def initialize(config)
     @config = config
     comment = config.payload['comment']['body'].strip.downcase
@@ -19,7 +18,8 @@ class Command
     end
 
     cmd = comment.delete_prefix(COMMAND_PREFIX).strip
-    @command, @options = cmd.split(/\s+/, 2)
+    @command, @options, @extra = cmd.split(/\s+/, 3)
+    puts "::debug::Command: #{@command}, Options: #{@options}, Extra: #{@extra}"
   end
 
   def call

--- a/spec/lib/command_spec.rb
+++ b/spec/lib/command_spec.rb
@@ -49,6 +49,28 @@ describe Command do
       end
     end
 
+    context 'when extra text is added to the command' do
+      let(:body) { '/dobby version minor please' }
+
+      it 'bumps the version when people are polite' do
+        action = double
+        allow(Action).to receive(:new).and_return(action)
+        expect(action).to receive(:initiate_version_update).with('minor')
+        Command.new(config).call
+      end
+    end
+
+    context 'when someone goes posts a long message about bumping the version' do
+      let(:body) { '/dobby version minor please, I really need this' }
+
+      it 'bumps the version' do
+        action = double
+        allow(Action).to receive(:new).and_return(action)
+        expect(action).to receive(:initiate_version_update).with('minor')
+        Command.new(config).call
+      end
+    end
+
     context 'when invalid command' do
       let(:body) { '/dobby barney laugh' }
 


### PR DESCRIPTION
This pull request adds the ability for users to include extra text in the command when interacting with the robot. Previously, only the command and options were accepted, but now users can provide additional information. This allows for more flexibility and better user experience.

This has added back the ability to say please
```
/dobby version patch please
```