### PR TITLE
Fix version handling

### DIFF
--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -6,7 +6,7 @@ require_relative 'commit'
 class Bump
   SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
-  VERSION_KEY = /(?:^|\.|\s|"|')(?:base|version)["']*/
+  VERSION_KEY = /(?:^|\.|\s|"|'|_*)(?:base|version)(?:_*["']*)/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config, level)

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe Bump do
     allow(commit).to receive(:multiple_files)
   end
 
+  describe 'VERSION_SETTING' do
+    it 'matches a lowercase, colon separated semver' do
+      version = 'version: 1.0.0'
+      expect(version.match(Bump::VERSION_SETTING)[0]).to eq(version)
+    end
+
+    it 'matches a lowercase, underscored, quote-marked, equal separated semver' do
+      version = '__version__ = "1.0.0"'
+      expect(version.match(Bump::VERSION_SETTING)[0]).to eq(version)
+    end
+  end
+
   describe '#bump_everything' do
     it 'bumps the version and commits the changes' do
       allow(head_content).to receive(:content).and_return('version: 1.0.0')
@@ -89,7 +101,7 @@ RSpec.describe Bump do
 
     it 'handles python underscored version format' do
       allow(head_content).to receive(:content).and_return('__version__ = "1.0.0"')
-      allow(base_content).to receive(:content).and_return('__version__ = "1.0.0"') 
+      allow(base_content).to receive(:content).and_return('__version__ = "1.0.0"')
 
       bump = Bump.new(config, 'patch')
       expect(commit).to receive(:multiple_files).with(

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -86,5 +86,23 @@ RSpec.describe Bump do
       )
       bump.bump_everything
     end
+
+    it 'handles python underscored version format' do
+      allow(head_content).to receive(:content).and_return('__version__ = "1.0.0"')
+      allow(base_content).to receive(:content).and_return('__version__ = "1.0.0"') 
+
+      bump = Bump.new(config, 'patch')
+      expect(commit).to receive(:multiple_files).with(
+        [
+          {
+            path: other_version_file_paths[0], mode: '100644', type: 'blob',
+            content: '__version__ = "1.0.1"'
+          },
+          { path: version_file_path, mode: '100644', type: 'blob', content: '__version__ = "1.0.1"' }
+        ],
+        'Bump patch version'
+      )
+      bump.bump_everything
+    end
   end
 end


### PR DESCRIPTION
A [recent use of dobby in a python repo](https://simplybusiness.slack.com/archives/CMNKUHCUB/p1731497978778889?thread_ts=1730277937.684459&cid=CMNKUHCUB) was failing because the format of the version key-value pair was not one Dobby was equipped to interpret.

This adds a test for that particular format as well as the standard format and applies a fix to the regex to get the test to pass.