### PR TITLE
minor fix in version regex

### DIFF
--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -6,7 +6,7 @@ require_relative 'commit'
 class Bump
   SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
-  VERSION_KEY = /(?:^|\.|\s|"|'|_*)(?:base|version)(?:_*["']*)/
+  VERSION_KEY = /(?:^_+|^|\.|\s|"|')(?:base|version)(?:["']*|_+)/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config, level)

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe Bump do
       version = '__version__ = "1.0.0"'
       expect(Bump::VERSION_SETTING).to match(version)
     end
+
+    it 'does not match unrelated semvers' do
+      version = 'expected_ruby_version = "3.3.0"'
+      expect(Bump::VERSION_SETTING).not_to match(version)
+    end
   end
 
   describe '#bump_everything' do

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe Bump do
   describe 'VERSION_SETTING' do
     it 'matches a lowercase, colon separated semver' do
       version = 'version: 1.0.0'
-      expect(version.match(Bump::VERSION_SETTING)[0]).to eq(version)
+      expect(Bump::VERSION_SETTING).to match(version)
     end
 
     it 'matches a lowercase, underscored, quote-marked, equal separated semver' do
       version = '__version__ = "1.0.0"'
-      expect(version.match(Bump::VERSION_SETTING)[0]).to eq(version)
+      expect(Bump::VERSION_SETTING).to match(version)
     end
   end
 


### PR DESCRIPTION
This is a minor change to keep the dobby version regex in line with the version-forget-me-not one. This will now still pick up python double underscored versioning like `__version__ = 3.0.0` but won't pick up non-related versioning like `expected_ruby_version = 3.3.0` 