### PR TITLE
Update Ubuntu runner image in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ on:
     types: [created]
 jobs:
   pr_commented:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: startsWith(github.event.comment.body, '/dobby')
     env:
       BUNDLE_WITHOUT: "development:test"


### PR DESCRIPTION
Update the `runs-on` label in the example workflow in `README.md` from `ubuntu-20.04` to `ubuntu-latest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/simplybusiness/dobby/pull/249?shareId=89b3d952-4292-481b-85b8-a7d56e1582f9).