### PR TITLE
add test for non-dobby command

### DIFF
--- a/spec/lib/command_spec.rb
+++ b/spec/lib/command_spec.rb
@@ -83,5 +83,13 @@ describe Command do
         Command.new(config).call
       end
     end
+
+    context 'when non-dobby command' do
+      let(:body) { '/bobby version patch' }
+
+      it 'raises error' do
+        expect { Command.new(config).call }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
I noticed there was a test for incorrect dobby commands, e.g. `dobby barney patch` but not for non-dobby commands, e.g. `bobby version patch`, even though there's specific logic for handling that. This adds that test for completeness.