### PR TITLE
Other version file patterns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,12 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 3.1
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ jobs:
           # OPTIONAL: Comma separated values for any other files that lock
           # their version to the same version in VERSION_FILE_PATH
           OTHER_VERSION_FILE_PATHS: 'package.json,package-lock.json,yarn.lock'
+          # OPTIONAL: Slash-separated strings to replace in the other version files
+          # Use the value 1.2.3 as the pattern, it will be replaced with the real
+          # version at runtime. This is to avoid changing not-relevant versions
+          # that might be the same as the library whose version you are bumping
+          OTHER_VERSION_PATTERNS: 'lib-name (1.2.3)/lib-name (= 1.2.3)/sub-lib-name (1.2.3)'
 ```
 
 **NOTE:** Workflow will only work once it merged to default (usually master) branch. It is because event `issue_comment` only work on default branch. See [discussion](https://github.community/t/on-issue-comment-events-are-not-triggering-workflows/16784/4) for more detail.

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -9,13 +9,14 @@ TEN_MINUTES = 600 # seconds
 
 # configuration for octokit
 class Config
-  attr_reader :client, :payload, :version_file_path, :other_version_file_paths, :event_name
+  attr_reader :client, :payload, :version_file_path, :other_version_file_paths, :other_version_patterns, :event_name
 
   def initialize
     @payload = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
     @event_name = ENV.fetch('GITHUB_EVENT_NAME')
     @version_file_path = ENV.fetch('VERSION_FILE_PATH').sub('./', '')
     @other_version_file_paths = ENV.fetch('OTHER_VERSION_FILE_PATHS', "").split(",")
+    @other_version_patterns = ENV.fetch('OTHER_VERSION_PATTERNS', '').split('/')
     @client = Octokit::Client.new(access_token: access_token)
   end
 

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Bump do
   let(:client) { instance_double(Octokit::Client) }
   let(:version_file_path) { 'path/to/version/file' }
   let(:other_version_file_paths) { ['path/to/other/version/file'] }
+  let(:other_version_patterns) { [] }
   let(:base_content) { instance_double(Content) }
   let(:head_content) { instance_double(Content) }
   let(:commit) { instance_double(Commit) }
@@ -18,7 +19,7 @@ RSpec.describe Bump do
   before do
     allow(config).to receive_messages(
       payload: payload, client: client, version_file_path: version_file_path,
-      other_version_file_paths: other_version_file_paths
+      other_version_file_paths: other_version_file_paths, other_version_patterns: other_version_patterns
     )
     allow(Content).to receive(:new).with(
       config: config, ref: 'base_branch',


### PR DESCRIPTION
Allow the other version file updates to be constrained to only the library being bumped and not other random libraries that happen to have the same version as the library being bumped.

There's an example in the tests to show how it doesn't incorrectly change an irrelevant library version in a Gemfile.spec with this new config.