### PR TITLE
Special case package-lock.json

### DIFF
--- a/lib/utils/bump.rb
+++ b/lib/utils/bump.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require_relative 'content'
 require_relative 'commit'
 
@@ -98,7 +99,9 @@ class Bump
   end
 
   def update_file_contents(path, contents)
-    if path != @version_file_path && @other_version_patterns.any?
+    if File.basename(path) == 'package-lock.json'
+      update_package_lock_contents(contents)
+    elsif path != @version_file_path && @other_version_patterns.any?
       @other_version_patterns.reduce(contents) do |new_contents, version_pattern|
         new_contents.gsub(
           version_pattern.sub('1.2.3', @version.to_s),
@@ -107,6 +110,24 @@ class Bump
       end
     else
       contents.gsub @version.to_s, @updated_version.to_s
+    end
+  end
+
+  # Node's package-lock.json file contains many version strings which can potentially match the version string we need
+  # to update. We restrict our regex replacement to the "version": line just below the "name": line that matches
+  # the top-level package name (i.e. the version of the main package and not any of its dependencies).
+  def update_package_lock_contents(contents)
+    parsed = JSON.parse(contents)
+    return contents unless parsed['version'] == @version.to_s
+
+    package_name = parsed['name']
+    # This pattern matches 2 adjacent lines, one beginning with "name" and the package name, the next being the
+    # current version string to replace with the new one. We then restrict our replace to only sections of the
+    # file that match this pattern.
+    pattern =
+      /"name"\s*:\s*"#{Regexp.escape(package_name)}"\s*,\n[^"]*"version"\s*:\s*"#{Regexp.escape(@version.to_s)}"/
+    contents.gsub(pattern) do |match|
+      match.gsub(@version.to_s, @updated_version.to_s)
     end
   end
 

--- a/spec/fixtures/package-lock.json
+++ b/spec/fixtures/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "my-package",
+      "version": "1.0.0",
+      "dependencies": {
+        "some-dep": "1.0.0",
+        "other-dep": "2.3.4"
+      }
+    },
+    "node_modules/some-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/some-dep/-/some-dep-1.0.0.tgz",
+      "integrity": "sha512-abc123"
+    },
+    "node_modules/other-dep": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/other-dep/-/other-dep-2.3.4.tgz",
+      "integrity": "sha512-def456"
+    }
+  }
+}

--- a/spec/lib/utils/bump_spec.rb
+++ b/spec/lib/utils/bump_spec.rb
@@ -109,6 +109,41 @@ RSpec.describe Bump do
       bump.bump_everything
     end
 
+    context 'when other version file is a package-lock.json' do
+      let(:other_version_file_paths) { ['package-lock.json'] }
+      let(:other_version_patterns) { [] }
+
+      it 'only updates the top-level version fields, not dependency versions' do
+        fixture = File.read(File.join(__dir__, '../../fixtures/package-lock.json'))
+
+        allow(base_content).to receive(:content).and_return('version: 1.0.0')
+
+        pkg_lock_content = instance_double(Content, content: fixture)
+        allow(Content).to receive(:new).with(
+          config: config, ref: 'head_branch', path: 'package-lock.json'
+        ).and_return(pkg_lock_content)
+
+        version_content = instance_double(Content, content: 'version: 1.0.0')
+        allow(Content).to receive(:new).with(
+          config: config, ref: 'head_branch', path: version_file_path
+        ).and_return(version_content)
+
+        bump = Bump.new(config, 'patch')
+
+        expect(commit).to receive(:multiple_files) do |files, _msg|
+          pkg_lock_file = files.find { |f| f[:path] == 'package-lock.json' }
+          parsed = JSON.parse(pkg_lock_file[:content])
+
+          expect(parsed['version']).to eq('1.0.1')
+          expect(parsed.dig('packages', '', 'version')).to eq('1.0.1')
+          expect(parsed.dig('packages', 'node_modules/some-dep', 'version')).to eq('1.0.0')
+          expect(parsed.dig('packages', 'node_modules/other-dep', 'version')).to eq('2.3.4')
+        end
+
+        bump.bump_everything
+      end
+    end
+
     it 'handles python underscored version format' do
       allow(head_content).to receive(:content).and_return('__version__ = "1.0.0"')
       allow(base_content).to receive(:content).and_return('__version__ = "1.0.0"')


### PR DESCRIPTION
Currently dobby completely breaks this file because it replaces every instance of the version string and that can match a LOT of different dependencies, either upgrading or downgrading them with reckless abandon. This has [broken semaphore-action](https://github.com/simplybusiness/semaphore-action/commit/88cd9514aa5bcc2fb6f8758d1dac30d5cbe9275c) already.

This bug fix doesn't require changing configuration, it just recognises when its dealing with Node lock files.

We can't handle this with `OTHER_VERSION_PATTERNS` because of the format of `package-lock.json` - the version we want to bump is on a line on its own like `"version": "1.2.3"` and from that alone, you've got no idea which version that is. See the linked commit where it bumped various other dependencies because they matched that string.